### PR TITLE
Choose the CDDL licence

### DIFF
--- a/taverna-server-webapp/src/misc/xsd/persistence_1_0.xsd
+++ b/taverna-server-webapp/src/misc/xsd/persistence_1_0.xsd
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- persistence.xml schema -->
+<!--
+      Apache Taverna elects to include this software in this
+      distribution under the CDDL license.
+-->
 <xsd:schema targetNamespace="http://java.sun.com/xml/ns/persistence" 
   xmlns:xsd="http://www.w3.org/2001/XMLSchema"
   xmlns:persistence="http://java.sun.com/xml/ns/persistence"


### PR DESCRIPTION
Comment added to file pointing out that Apache Taverna chooses the CDDL licence and not GPL2.